### PR TITLE
go-repo-export: fix module name (`go-repo-export` vs `go-export-repo`)

### DIFF
--- a/go-repo-export/go.mod
+++ b/go-repo-export/go.mod
@@ -1,4 +1,4 @@
-module github.com/bluesky-social/cookbook/go-export-repo
+module github.com/bluesky-social/cookbook/go-repo-export
 
 go 1.21.0
 


### PR DESCRIPTION
fixing error due confusion between `go-repo-export` and `go-export-repo`

```bash
> go install github.com/bluesky-social/cookbook/go-repo-export@latest

go: github.com/bluesky-social/cookbook/go-repo-export@latest: version constraints conflict:
	github.com/bluesky-social/cookbook/go-repo-export@v0.0.0-20231104010341-e8067366c178: parsing go.mod:
	module declares its path as: github.com/bluesky-social/cookbook/go-export-repo
	        but was required as: github.com/bluesky-social/cookbook/go-repo-export
```