### PR TITLE
Proposal: Add ability to quickly run starter project on Val Town

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@ A collection of example projects and scripts for atproto development.
 
 * [How to make a post in Bluesky (Python)](/python-bsky-post/README.md)
 * [Starter kit for a Bluesky bot (TypeScript)](/ts-bot/README.md)
+
+  [![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/x/charmaine/blueskyBotTutorial)
 * [Download and Inspect Repository (Go)](/go-repo-export/README.md)
 * [OAuth Web Service (Python)](/python-oauth-web-app/README.md)

--- a/ts-bot/README.md
+++ b/ts-bot/README.md
@@ -3,7 +3,7 @@
 This folder contains a starter template for creating a bot on Bluesky. In this example, the bot posts a smiley emoji on an automated schedule once every three hours.
 
 ## Set Up
-
+[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/x/charmaine/blueskyBotTutorial)
 1. Install Typescript: `npm i -g typescript`
 2. Install Node.js: `npm i -g ts-node`
 3. Make a copy of the example `.env` file by running: `cp example.env .env`. Set your username and password in `.env`. Use an App Password.

--- a/ts-bot/README.md
+++ b/ts-bot/README.md
@@ -14,5 +14,5 @@ This folder contains a starter template for creating a bot on Bluesky. In this e
 2. Modify the script however you like to make this bot your own! 
 
 ## Deploying your bot
-1. You can deploy a simple bot for free or low cost on a variety of platforms. For example, check out [Heroku](https://devcenter.heroku.com/articles/github-integration) or [Fly.io](https://fly.io/docs/reference/fly-launch/).
+1. You can deploy a simple bot for free or low cost on a variety of platforms. For example, check out [Heroku](https://devcenter.heroku.com/articles/github-integration) or [Fly.io](https://fly.io/docs/reference/fly-launch/), or [Val Town](https://www.val.town/x/charmaine/blueskyBotTutorial) as listed above.
 


### PR DESCRIPTION
Hey there! 

I’d love to propose adding a [Val Town](https://www.val.town/) badge to the README so new users can spin up a client for their own Bluesky bot in just one click.

I work at Val Town and it would mean the world to us to contribute to Bluesky's developer community. Val Town lets users run scripts and cron jobs without additional configurations or backends / servers, which seems perfect for [examples like this](https://docs.bsky.app/docs/starter-templates/bots). 

## Proposed badge in README:
[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/x/charmaine/blueskyBotTutorial)

## In action:
![Clipboard-20250204-211620-354](https://github.com/user-attachments/assets/56ac98f2-1889-4cce-95c1-8b7a22372a42)

## Why this could be helpful:
1.  Gives users instant access to a working example.
2.  Lets them fork and customize the example in a single click.
3.  Helps avoid local development headaches (like node/npm issues) so users can focus on your API instead.

We recently did this with [Steel's Cookbook](https://github.com/steel-dev/steel-cookbook/blob/main/examples/steel-puppeteer-starter/README.md) and they were [super excited about it](https://x.com/hussufo/status/1884332147122766090), so we thought it'd be awesome to bring the same experience to Bluesky. 

We’re happy to help maintain this starter on Val Town as your API evolves, or you’re welcome to fork it so you have full control.

This PR should be good to go as-is, but we’d love to hear your thoughts! 😊