### PR TITLE
add nextjs oauth tutorial as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nextjs-oauth"]
+	path = nextjs-oauth
+	url = https://github.com/bluesky-social/nextjs-oauth-tutorial


### PR DESCRIPTION
Keeping this in a separate repo to make Railway deploys easier, but adding as a submodule for discoverability.